### PR TITLE
Update web3-utils version in packages/protocol

### DIFF
--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "bn.js": "^4.11.8",
     "elliptic": "^6.5.3",
-    "web3-utils": "1.2.8"
+    "@photic/web3-utils": "^1.3.7"
   },
   "devDependencies": {
     "eslint": "^5.16.0",


### PR DESCRIPTION
Usage in the directory seems non-existent, but i'm not sure I want to remove the dependency (not sure what can of worms that's going to open):

```
package.json:    "@photic/web3-utils": "^1.3.7"
test/zsc.js:        var receipt = await web3.eth.getTransactionReceipt(resp.tx);
```